### PR TITLE
Uclibc ld.so support.

### DIFF
--- a/ucore/src/kern-ucore/arch/amd64/include.mk
+++ b/ucore/src/kern-ucore/arch/amd64/include.mk
@@ -1,3 +1,3 @@
 ARCH_INLUCDES := . debug driver include libs mm numa process sync trap syscall kmodule driver/acpica/source/include
-ARCH_CFLAGS := -m64 -mcmodel=large -D__UCORE
+ARCH_CFLAGS := -m64 -mcmodel=large -D__UCORE -DARCH_AMD64
 ARCH_LDFLAGS := -melf_x86_64

--- a/ucore/src/kern-ucore/arch/amd64/mm/memlayout.h
+++ b/ucore/src/kern-ucore/arch/amd64/mm/memlayout.h
@@ -89,7 +89,8 @@
 #define USTACKPAGE          4096	// # of pages in user stack
 #define USTACKSIZE          (USTACKPAGE * PGSIZE)	// sizeof user stack
 
-#define USERBASE            0x0000000001000000
+//#define USERBASE            0x0000000001000000
+#define USERBASE            0x0000000000000000
 #define UTEXT               0x0000000010000000	// where user programs generally begin
 #define USTAB               USERBASE	// the location of the user STABS data structure
 

--- a/ucore/src/kern-ucore/arch/amd64/process/arch_proc.h
+++ b/ucore/src/kern-ucore/arch/amd64/process/arch_proc.h
@@ -27,9 +27,9 @@ struct arch_proc_struct {
 };
 
 //Bionic C related context initialization code
-int init_new_context_dynamic(struct proc_struct *proc, struct elfhdr *elf,
-			     int argc, char **kargv, int envc, char **kenvp,
-			     uint64_t is_dynamic, uint64_t real_entry,
-			     uint64_t load_address, uint64_t linker_base);
+int init_new_context_dynamic(struct proc_struct *proc, struct elfhdr *elf, int argc,
+			 char **kargv, int envc, char **kenvp,
+			 uint64_t elf_have_interpreter, uint64_t interpreter_entry,
+			 uint64_t elf_entry, uint64_t linker_base, void* program_header_address);
 
 #endif /* !__ARCH_PROC_H__ */

--- a/ucore/src/kern-ucore/arch/amd64/process/proc.c
+++ b/ucore/src/kern-ucore/arch/amd64/process/proc.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <types.h>
 #include <stdlib.h>
+#include <elf.h>
 #include <mp.h>
 
 void forkret(void);
@@ -94,44 +95,108 @@ int kernel_execve(const char *name, const char **argv, const char **kenvp)
 	return ret;
 }
 
-int
-init_new_context(struct proc_struct *proc, struct elfhdr *elf,
-		 int argc, char **kargv, int envc, char **kenvp)
+int init_new_context_dynamic(struct proc_struct *proc, struct elfhdr *elf, int argc,
+			 char **kargv, int envc, char **kenvp,
+			 uint64_t is_dynamic, uint64_t real_entry,
+			 uint64_t load_address, uint64_t linker_base)
 {
-	uintptr_t stacktop = USTACKTOP - argc * PGSIZE;
-	char **uargv = (char **)(stacktop - argc * sizeof(char *));
-	int i;
-	for (i = 0; i < argc; i++) {
-		uargv[i] = strcpy((char *)(stacktop + i * PGSIZE), kargv[i]);
-    //TODO: Seems __strcpy for amd64 has a bug, always returning 0,
-    //But I don't find the exact reason so the following work around is used.
-    uargv[i] = (char *)(stacktop + i * PGSIZE);
-	}
-	stacktop = (uintptr_t) uargv;
+  //Conclude this by using LD_SHOW_AUXV=1 on my laptop running Linux 4.5.4
+  const int ELF_AUXILIARY_VECTOR_COUNT = 19;
+  char* stack_top = USTACKTOP;
 
-	struct trapframe *tf = current->tf;
+  size_t stack_param_size = 0;
+  stack_param_size += sizeof(uint64_t);
+  stack_param_size += (argc + 1) * sizeof(char**);
+  stack_param_size += (envc + 1) * sizeof(char**);
+  for(int i = 0; i < argc; i++) {
+    stack_param_size += strlen(kargv[i]) + 1;
+  }
+  for(int i = 0; i < envc; i++) {
+    stack_param_size += strlen(kenvp[i]) + 1;
+  }
+  stack_param_size +=
+    ELF_AUXILIARY_VECTOR_COUNT * sizeof(struct elf64_auxiliary_vector);
+
+  stack_top -= stack_param_size;
+
+  char* stack_pos = stack_top;
+  *((uint64_t*)stack_pos) = argc;
+  stack_pos += sizeof(uint64_t);
+  char **new_argv = (char**)stack_pos;
+  stack_pos += (argc + 1) * sizeof(char**);
+  char **new_envp = (char**)stack_pos;
+  stack_pos += (envc + 1) * sizeof(char**);
+  struct elf64_auxiliary_vector* auxiliary_vector = (struct elf64_auxiliary_vector*)stack_pos;
+  stack_pos += ELF_AUXILIARY_VECTOR_COUNT * sizeof(struct elf64_auxiliary_vector);
+
+  //TODO: Seems __strcpy for amd64 has a bug, always returning 0, instead
+  //of the end of the destination string.
+  //But I don't find the exact reason so the some strlen after strcpy is used.
+  for(int i = 0; i < argc; i++) {
+    strcpy(stack_pos, kargv[i]);
+    new_argv[i] = stack_pos;
+    stack_pos += strlen(kargv[i]) + 1;
+  }
+  new_argv[argc] = NULL;
+  for(int i = 0; i < envc; i++) {
+    strcpy(stack_pos, kenvp[i]);
+    new_envp[i] = stack_pos;
+    stack_pos += (strlen(kenvp[i]) + 1);
+  }
+  new_envp[envc] = NULL;
+
+  auxiliary_vector[0].a_type = AT_IGNORE; //AT_SYSINFO_EHDR
+  //We don't have the vDSO
+  auxiliary_vector[1].a_type = AT_IGNORE; //AT_HWCAP
+  //TODO: Add hardware detection data
+  auxiliary_vector[2].a_type = AT_PAGESZ;
+  auxiliary_vector[2].a_val = PGSIZE;
+  auxiliary_vector[3].a_type = AT_CLKTCK;
+  auxiliary_vector[3].a_val = 100;
+  auxiliary_vector[4].a_type = AT_IGNORE; //AT_PHDR
+  auxiliary_vector[5].a_type = AT_PHENT;
+  auxiliary_vector[5].a_val = elf->e_phentsize;
+  auxiliary_vector[6].a_type = AT_PHNUM;
+  auxiliary_vector[6].a_val = elf->e_phnum;
+  auxiliary_vector[7].a_type = AT_BASE; //The base address of the program interpreter
+  auxiliary_vector[7].a_val = 0; //TODO
+  auxiliary_vector[8].a_type = AT_FLAGS;
+  auxiliary_vector[8].a_val = 0;
+  auxiliary_vector[9].a_type = AT_ENTRY;
+  auxiliary_vector[9].a_val = elf->e_entry; //TODO
+
+  //TODO: Currently uCore doesn't support multi-user. So we're simulating
+  //The user root and the group root.
+  auxiliary_vector[10].a_type = AT_UID;
+  auxiliary_vector[11].a_type = AT_EUID;
+  auxiliary_vector[12].a_type = AT_GID;
+  auxiliary_vector[13].a_type = AT_EGID;
+  for(int i = 10; i <= 13; i++) {
+    auxiliary_vector[i].a_val = 0;
+  }
+  auxiliary_vector[14].a_type = AT_SECURE;
+  auxiliary_vector[14].a_val = 0;
+  auxiliary_vector[15].a_type = AT_RANDOM;
+  auxiliary_vector[15].a_val = rand();
+  //auxiliary_vector[16].a_type = AT_PLATFORM;
+  //auxiliary_vector[17].a_type = AT_EXECFN;
+  auxiliary_vector[16].a_type = AT_NULL;
+  auxiliary_vector[16].a_val = 0;
+  struct trapframe *tf = current->tf;
 	memset(tf, 0, sizeof(struct trapframe));
 	tf->tf_cs = USER_CS;
 	tf->tf_ds = USER_DS;
 	tf->tf_es = USER_DS;
 	tf->tf_ss = USER_DS;
-	tf->tf_rsp = stacktop;
+	tf->tf_rsp = (uint64_t)stack_top;
 	tf->tf_rip = elf->e_entry;
 	tf->tf_rflags = FL_IF;
-	tf->tf_regs.reg_rdi = argc;
-	tf->tf_regs.reg_rsi = (uintptr_t) uargv;
 
+  //Only uCore built-in utilities cares about this - C library likes uClibc only
+  //looks up data on the stack.
+	tf->tf_regs.reg_rdi = (uint64_t)argc;
+	tf->tf_regs.reg_rsi = (uintptr_t)new_argv;
 	return 0;
-}
-
-//TODO: Bionic C related code requires this function to be implemented.
-int
-init_new_context_dynamic(struct proc_struct *proc, struct elfhdr *elf, int argc,
-			 char **kargv, int envc, char **kenvp,
-			 uint64_t is_dynamic, uint64_t real_entry,
-			 uint64_t load_address, uint64_t linker_base)
-{
-  init_new_context(proc, elf, argc, kargv, envc, kenvp);
 }
 
 // cpu_idle - at the end of kern_init, the first kernel thread idleproc will do below works

--- a/ucore/src/kern-ucore/arch/amd64/syscall/syscall.c
+++ b/ucore/src/kern-ucore/arch/amd64/syscall/syscall.c
@@ -718,7 +718,7 @@ static uint64_t(*syscalls_linux[305]) (uint64_t arg[]) = {
 	[__NR_lseek] unknown,
 	[__NR_mmap] sys_linux_mmap,
 	[__NR_mprotect] unknown,
-	[__NR_munmap] unknown,
+	[__NR_munmap] sys_munmap,
 	[__NR_brk] __sys_linux_brk,
 	[__NR_rt_sigaction] sys_linux_sigaction,
 	[__NR_rt_sigprocmask] sys_linux_sigprocmask,

--- a/ucore/src/kern-ucore/arch/amd64/syscall/syscall.c
+++ b/ucore/src/kern-ucore/arch/amd64/syscall/syscall.c
@@ -54,7 +54,16 @@ static uint64_t sys_clone(uint64_t arg[])
 	if (stack == 0) {
 		stack = tf->tf_rsp;
 	}
-	return do_fork(clone_flags, stack, tf);
+  long thread_id = do_fork(clone_flags, stack, tf);
+  if(clone_flags & CLONE_CHILD_SETTID) {
+    long* child_tid_storage = arg[3];
+    *child_tid_storage = thread_id;
+  }
+  if(clone_flags & CLONE_PARENT_SETTID) {
+    long* parent_tid_storage = arg[2];
+    *parent_tid_storage = thread_id;
+  }
+  return thread_id;
 }
 
 static uint64_t sys_exit_thread(uint64_t arg[])
@@ -63,7 +72,7 @@ static uint64_t sys_exit_thread(uint64_t arg[])
 	return do_exit_thread(error_code);
 }
 
-static uint64_t __sys_linux_exit_group(uint64_t arg[])
+static uint64_t sys_linux_exit_group(uint64_t arg[])
 {
 	int error_code = (int)arg[0];
 	return do_exit(error_code);
@@ -224,6 +233,7 @@ static uint64_t sys_mbox_info(uint64_t arg[])
 static uint64_t sys_open(uint64_t arg[])
 {
 	const char *path = (const char *)arg[0];
+  //kprintf("opening %s\r\n", path);
 	uint32_t open_flags = (uint32_t) arg[1];
 	return sysfile_open(path, open_flags);
 }
@@ -458,7 +468,7 @@ static uint64_t sys_setrlimit(uint64_t arg[])
 	return do_linux_usetrlimit(res, lim);
 }
 
-static uint64_t __sys_linux_brk(uint64_t arg[])
+static uint64_t sys_linux_brk(uint64_t arg[])
 {
 	uintptr_t brk = (uintptr_t) arg[0];
 	return do_linux_brk(brk);
@@ -470,7 +480,7 @@ static uint64_t sys_linux_sigaction(uint64_t arg[])
 			    (struct sigaction *)arg[2]);
 }
 
-static uint64_t __sys_linux_sigreturn(uint64_t arg[])
+static uint64_t sys_linux_sigreturn(uint64_t arg[])
 {
   return do_sigreturn();
 }
@@ -481,12 +491,12 @@ static uint64_t sys_linux_sigprocmask(uint64_t arg[])
 			      (sigset_t *) arg[2]);
 }
 
-static uint64_t __sys_linux_fcntl(uint64_t arg[])
+static uint64_t sys_linux_fcntl(uint64_t arg[])
 {
 	return sysfile_linux_fcntl64(arg[0], arg[1], arg[2]);
 }
 
-static uint64_t __sys_linux_getdents(uint64_t arg[])
+static uint64_t sys_linux_getdents(uint64_t arg[])
 {
 	unsigned int fd = (unsigned int)arg[0];
 	struct dirent *dir = (struct dirent *)arg[1];
@@ -498,7 +508,7 @@ static uint64_t __sys_linux_getdents(uint64_t arg[])
 	return count;
 }
 
-static uint64_t __sys_linux_getdents64(uint64_t arg[])
+static uint64_t sys_linux_getdents64(uint64_t arg[])
 {
   unsigned int fd = (unsigned int)arg[0];
 	struct dirent64 *dir = (struct dirent64 *)arg[1];
@@ -521,7 +531,7 @@ static uint64_t sys_linux_mmap(uint64_t arg[])
   size_t off = (size_t) arg[5];
   #ifndef UCONFIG_BIONIC_LIBC
   	kprintf
-  	    ("TODO __sys_linux_mmap2 addr=%llx len=%llx prot=%llx flags=%llx fd=%d off=%llx\n",
+  	    ("TODO sys_linux_mmap2 addr=%llx len=%llx prot=%llx flags=%llx fd=%d off=%llx\n",
   	     addr, len, prot, flags, fd, off);
   #endif //UCONFIG_BIONIC_LIBC
   	if (fd == -1 || flags & MAP_ANONYMOUS) {
@@ -548,21 +558,21 @@ static uint64_t sys_linux_mmap(uint64_t arg[])
   	}
 }
 
-static uint64_t __sys_linux_stat(uint64_t args[])
+static uint64_t sys_linux_stat(uint64_t args[])
 {
 	char *fn = (char *)args[0];
 	struct linux_stat *st = (struct linux_stat *)args[1];
 	return sysfile_linux_stat64(fn, st);
 }
 
-static uint64_t __sys_linux_fstat(uint64_t args[])
+static uint64_t sys_linux_fstat(uint64_t args[])
 {
 	int fd = (char *)args[0];
 	struct linux_stat *st = (struct linux_stat *)args[1];
 	return sysfile_linux_fstat64(fd, st);
 }
 
-static uint64_t __sys_linux_waitpid(uint64_t arg[])
+static uint64_t sys_linux_waitpid(uint64_t arg[])
 {
 	int pid = (int)arg[0];
 	int *store = (int *)arg[1];
@@ -573,7 +583,7 @@ static uint64_t __sys_linux_waitpid(uint64_t arg[])
 	return do_linux_waitpid(pid, store);
 }
 
-static uint64_t __sys_linux_nanosleep(uint64_t arg[])
+static uint64_t sys_linux_nanosleep(uint64_t arg[])
 {
 	//TODO: handle signal interrupt
 	struct linux_timespec *req = (struct linux_timespec *)arg[0];
@@ -581,7 +591,7 @@ static uint64_t __sys_linux_nanosleep(uint64_t arg[])
 	return do_linux_sleep(req, rem);
 }
 
-static uint64_t __sys_linux_pipe(uint64_t arg[])
+static uint64_t sys_linux_pipe(uint64_t arg[])
 {
 	int *fd_store = (int *)arg[0];
 	return sysfile_pipe(fd_store) ? -1 : 0;
@@ -595,7 +605,7 @@ static uint64_t __sys_linux_pipe(uint64_t arg[])
                           int __user *parent_tidptr, int tls_val,
                           int __user *child_tidptr, struct pt_regs *regs)
  */
-static uint64_t __sys_linux_clone(uint64_t arg[])
+static uint64_t sys_linux_clone(uint64_t arg[])
 {
 	struct trapframe *tf = current->tf;
 	uint64_t clone_flags = (uint64_t) arg[0];
@@ -611,7 +621,7 @@ static uint64_t sys_linux_sigsuspend(uint64_t arg[])
 	return do_sigsuspend((sigset_t *) arg[0]);
 }
 
-static uint64_t __sys_linux_getppid(uint64_t arg[])
+static uint64_t sys_linux_getppid(uint64_t arg[])
 {
 	struct proc_struct *parent = current->parent;
 	if (!parent)
@@ -625,7 +635,7 @@ struct linux_pollfd {
 	short revents;		/* returned events */
 };
 
-static uint64_t __sys_linux_poll(uint64_t arg[])
+static uint64_t sys_linux_poll(uint64_t arg[])
 {
 	//FIXME
 	struct linux_pollfd *fd = (struct linux_pollfd *)arg[0]; // can be hacked
@@ -635,7 +645,7 @@ static uint64_t __sys_linux_poll(uint64_t arg[])
 	return nfds;
 }
 
-static uint64_t __sys_linux_readlinkat(uint64_t arg[])
+static uint64_t sys_linux_readlinkat(uint64_t arg[])
 {
   //TODO: This is a stub function.
   return -E_NOENT;
@@ -646,7 +656,7 @@ const static int ARCH_SET_FS = 0x1002;
 const static int ARCH_GET_FS = 0x1003;
 const static int ARCH_GET_GS = 0x1004;
 
-static uint64_t __sys_linux_arch_prctl(uint64_t arg[])
+static uint64_t sys_linux_arch_prctl(uint64_t arg[])
 {
   int code = (int)arg[0];
   if(code == ARCH_SET_GS) {
@@ -672,7 +682,7 @@ static uint64_t __sys_linux_arch_prctl(uint64_t arg[])
   return 0;
 }
 
-static uint64_t __sys_linux_mprotect(uint64_t arg[])
+static uint64_t sys_linux_mprotect(uint64_t arg[])
 {
 
 	void *addr = (void *)arg[0];
@@ -684,13 +694,13 @@ static uint64_t __sys_linux_mprotect(uint64_t arg[])
 	return do_mprotect(addr, len, prot);
 }
 
-static uint64_t __sys_linux_set_tid_address(uint64_t arg[])
+static uint64_t sys_linux_set_tid_address(uint64_t arg[])
 {
   //TODO: This is a stub function.
-  return 0;
+  return current->tid + 1;
 }
 
-static uint64_t __sys_set_robust_list(uint64_t arg[])
+static uint64_t sys_linux_set_robust_list(uint64_t arg[])
 {
   //TODO: This is a stub function.
   return 0;
@@ -701,8 +711,7 @@ static uint64_t sys_linux_sigkill(uint64_t arg[])
 	return do_sigkill((int)arg[0], (int)arg[1]);
 }
 
-#define __sys_linux_sigkill sys_linux_sigkill
-#define __sys_linux_kill    sys_linux_sigkill
+#define sys_linux_kill    sys_linux_sigkill
 
 
 uint64_t unknown(uint64_t arg[])
@@ -728,7 +737,7 @@ void syscall_linux()
 	struct trapframe *tf = current->tf;
 	uint64_t arg[6];
 	int num = tf->tf_regs.reg_rax;
-  //kprintf("LINUX syscall %d  gs = 0x%x rip = %llx\n", num, mycpu(), tf->tf_rip);
+  //kprintf("LINUX syscall %d  gs = 0x%x fs = %llx rip = %llx\n", num, mycpu(), readmsr(MSR_FS_BASE), tf->tf_rip);
 	if (num >= 0 && num < NUM_LINUX_SYSCALLS) {
     /*if(num == __NR_execve) {
       kprintf("Beginning execve= =\r\n");
@@ -763,25 +772,25 @@ static uint64_t(*syscalls_linux[305]) (uint64_t arg[]) = {
 	[__NR_write] sys_write,
 	[__NR_open] sys_open,
 	[__NR_close] sys_close,
-	[__NR_stat] __sys_linux_stat,
-	[__NR_fstat] __sys_linux_fstat,
+	[__NR_stat] sys_linux_stat,
+	[__NR_fstat] sys_linux_fstat,
 	[__NR_lstat] unknown,
-	[__NR_poll] __sys_linux_poll,
+	[__NR_poll] sys_linux_poll,
 	[__NR_lseek] unknown,
 	[__NR_mmap] sys_linux_mmap,
-	[__NR_mprotect] __sys_linux_mprotect,
+	[__NR_mprotect] sys_linux_mprotect,
 	[__NR_munmap] sys_munmap,
-	[__NR_brk] __sys_linux_brk,
+	[__NR_brk] sys_linux_brk,
 	[__NR_rt_sigaction] sys_linux_sigaction,
 	[__NR_rt_sigprocmask] sys_linux_sigprocmask,
-	[__NR_rt_sigreturn] __sys_linux_sigreturn,
+	[__NR_rt_sigreturn] sys_linux_sigreturn,
 	[__NR_ioctl] sys_ioctl,
 	[__NR_pread64] unknown,
 	[__NR_pwrite64] unknown,
 	[__NR_readv] unknown,
 	[__NR_writev] unknown,
 	[__NR_access] unknown,
-	[__NR_pipe] __sys_linux_pipe,
+	[__NR_pipe] sys_linux_pipe,
 	[__NR_select] unknown,
 	[__NR_sched_yield] unknown,
 	[__NR_mremap] unknown,
@@ -794,7 +803,7 @@ static uint64_t(*syscalls_linux[305]) (uint64_t arg[]) = {
 	[__NR_dup] unknown,
 	[__NR_dup2] unknown,
 	[__NR_pause] unknown,
-	[__NR_nanosleep] __sys_linux_nanosleep,
+	[__NR_nanosleep] sys_linux_nanosleep,
 	[__NR_getitimer] unknown,
 	[__NR_alarm] unknown,
 	[__NR_setitimer] unknown,
@@ -815,13 +824,13 @@ static uint64_t(*syscalls_linux[305]) (uint64_t arg[]) = {
 	[__NR_socketpair] unknown,
 	[__NR_setsockopt] unknown,
 	[__NR_getsockopt] unknown,
-	[__NR_clone] __sys_linux_clone,
+	[__NR_clone] sys_linux_clone,
 	[__NR_fork] sys_fork,
 	[__NR_vfork] unknown,
 	[__NR_execve] sys_execve,
 	[__NR_exit] sys_exit,
-	[__NR_wait4] __sys_linux_waitpid,
-	[__NR_kill] __sys_linux_kill,
+	[__NR_wait4] sys_linux_waitpid,
+	[__NR_kill] sys_linux_kill,
 	[__NR_uname] unknown,
 	[__NR_semget] unknown,
 	[__NR_semop] unknown,
@@ -831,13 +840,13 @@ static uint64_t(*syscalls_linux[305]) (uint64_t arg[]) = {
 	[__NR_msgsnd] unknown,
 	[__NR_msgrcv] unknown,
 	[__NR_msgctl] unknown,
-	[__NR_fcntl] __sys_linux_fcntl,
+	[__NR_fcntl] sys_linux_fcntl,
 	[__NR_flock] unknown,
 	[__NR_fsync] unknown,
 	[__NR_fdatasync] unknown,
 	[__NR_truncate] unknown,
 	[__NR_ftruncate] unknown,
-	[__NR_getdents] __sys_linux_getdents,
+	[__NR_getdents] sys_linux_getdents,
 	[__NR_getcwd] unknown,
 	[__NR_chdir] unknown,
 	[__NR_fchdir] unknown,
@@ -869,7 +878,7 @@ static uint64_t(*syscalls_linux[305]) (uint64_t arg[]) = {
 	[__NR_geteuid] unknown,
 	[__NR_getegid] unknown,
 	[__NR_setpgid] unknown,
-	[__NR_getppid] __sys_linux_getppid,
+	[__NR_getppid] sys_linux_getppid,
 	[__NR_getpgrp] unknown,
 	[__NR_setsid] unknown,
 	[__NR_setreuid] unknown,
@@ -917,7 +926,7 @@ static uint64_t(*syscalls_linux[305]) (uint64_t arg[]) = {
 	[__NR_pivot_root] unknown,
 	[__NR__sysctl] unknown,
 	[__NR_prctl] unknown,
-	[__NR_arch_prctl] __sys_linux_arch_prctl,
+	[__NR_arch_prctl] sys_linux_arch_prctl,
 	[__NR_adjtimex] unknown,
 	[__NR_setrlimit] sys_setrlimit,
 	[__NR_chroot] unknown,
@@ -976,8 +985,8 @@ static uint64_t(*syscalls_linux[305]) (uint64_t arg[]) = {
 	[__NR_epoll_ctl_old] unknown,
 	[__NR_epoll_wait_old] unknown,
 	[__NR_remap_file_pages] unknown,
-	[__NR_getdents64] __sys_linux_getdents64,
-	[__NR_set_tid_address] __sys_linux_set_tid_address,
+	[__NR_getdents64] sys_linux_getdents64,
+	[__NR_set_tid_address] sys_linux_set_tid_address,
 	[__NR_restart_syscall] unknown,
 	[__NR_semtimedop] unknown,
 	[__NR_fadvise64] unknown,
@@ -990,7 +999,7 @@ static uint64_t(*syscalls_linux[305]) (uint64_t arg[]) = {
 	[__NR_clock_gettime] unknown,
 	[__NR_clock_getres] unknown,
 	[__NR_clock_nanosleep] unknown,
-	[__NR_exit_group] __sys_linux_exit_group,
+	[__NR_exit_group] sys_linux_exit_group,
 	[__NR_epoll_wait] unknown,
 	[__NR_epoll_ctl] unknown,
 	[__NR_tgkill] unknown,
@@ -1026,13 +1035,13 @@ static uint64_t(*syscalls_linux[305]) (uint64_t arg[]) = {
 	[__NR_renameat] unknown,
 	[__NR_linkat] unknown,
 	[__NR_symlinkat] unknown,
-	[__NR_readlinkat] __sys_linux_readlinkat,
+	[__NR_readlinkat] sys_linux_readlinkat,
 	[__NR_fchmodat] unknown,
 	[__NR_faccessat] unknown,
 	[__NR_pselect6] unknown,
 	[__NR_ppoll] unknown,
 	[__NR_unshare] unknown,
-	[__NR_set_robust_list] __sys_set_robust_list,
+	[__NR_set_robust_list] sys_linux_set_robust_list,
 	[__NR_get_robust_list] unknown,
 	[__NR_splice] unknown,
 	[__NR_tee] unknown,

--- a/ucore/src/kern-ucore/arch/amd64/syscall/syscall.c
+++ b/ucore/src/kern-ucore/arch/amd64/syscall/syscall.c
@@ -512,11 +512,12 @@ static uint64_t sys_linux_mmap(uint64_t arg[])
   int flags = (int)arg[3];
   int fd = (int)arg[4];
   size_t off = (size_t) arg[5];
-  //kprintf("addr = %x, len = %d, fd = %d, off = %d\r\n", addr, len, fd, off);
+  if(len > (uint64_t)0x80000000) return -E_INVAL;
+  kprintf("addr = %llx, len = %d, fd = %d, off = %d\r\n", addr, len, fd, off);
 	//return (uint64_t) sysfile_linux_mmap2(addr, len, prot, flags, fd, off);
   #ifndef UCONFIG_BIONIC_LIBC
   	kprintf
-  	    ("TODO __sys_linux_mmap2 addr=%08x len=%08x prot=%08x flags=%08x fd=%d off=%08x\n",
+  	    ("TODO __sys_linux_mmap2 addr=%llx len=%llx prot=%llx flags=%llx fd=%d off=%llx\n",
   	     addr, len, prot, flags, fd, off);
   #endif //UCONFIG_BIONIC_LIBC
   	if (fd == -1 || flags & MAP_ANONYMOUS) {
@@ -532,10 +533,10 @@ static uint64_t sys_linux_mmap(uint64_t arg[])
   		if (prot & PROT_WRITE)
   			ucoreflags |= MMAP_WRITE;
   		int ret = __do_linux_mmap((uintptr_t) & addr, len, ucoreflags);
-  		//kprintf("@@@ ret=%d %e %08x\n", ret,ret, addr);
+  		kprintf("@@@ ret=%d %e %llx\n", ret,ret, addr);
   		if (ret)
   			return (uint64_t)MAP_FAILED;
-  		//kprintf("__sys_linux_mmap2 ret=%08x\n", addr);
+  		kprintf("__sys_linux_mmap2 ret=%llx\n", addr);
   		return (uint64_t) addr;
   	} else {
   		return (uint64_t) sysfile_linux_mmap2(addr, len, prot, flags,
@@ -630,6 +631,12 @@ static uint64_t __sys_linux_poll(uint64_t arg[])
 	return nfds;
 }
 
+static uint64_t __sys_linux_readlinkat(uint64_t arg[])
+{
+  //TODO: This is a stub function.
+  return E_NOENT;
+}
+
 static uint64_t sys_linux_sigkill(uint64_t arg[])
 {
 	return do_sigkill((int)arg[0], (int)arg[1]);
@@ -675,8 +682,8 @@ void syscall_linux()
     }*/
 		if (syscalls_linux[num] != unknown)
 		if (syscalls_linux[num] != NULL) {
-	    //kprintf("%d : LINUX syscall %d, pid = %d, name = %s rip = %lx  ARGS :\r\n", ++count, num, current->pid, current->name
-      //  , tf->tf_rip);
+	    kprintf("%d : LINUX syscall %d, pid = %d, name = %s rip = %lx  ARGS :\r\n", ++count, num, current->pid, current->name
+        , tf->tf_rip);
 	    arg[0] = tf->tf_regs.reg_rdi;
 			arg[1] = tf->tf_regs.reg_rsi;
 			arg[2] = tf->tf_regs.reg_rdx;
@@ -974,7 +981,7 @@ static uint64_t(*syscalls_linux[305]) (uint64_t arg[]) = {
 	[__NR_renameat] unknown,
 	[__NR_linkat] unknown,
 	[__NR_symlinkat] unknown,
-	[__NR_readlinkat] unknown,
+	[__NR_readlinkat] __sys_linux_readlinkat,
 	[__NR_fchmodat] unknown,
 	[__NR_faccessat] unknown,
 	[__NR_pselect6] unknown,

--- a/ucore/src/kern-ucore/arch/amd64/trap/trap.c
+++ b/ucore/src/kern-ucore/arch/amd64/trap/trap.c
@@ -214,10 +214,12 @@ uintptr_t addr;
 			if (current == NULL) {
 				panic("handle pgfault failed. %e\n", ret);
 			} else {
+        uintptr_t addr = rcr2();
 				if (trap_in_kernel(tf)) {
+          print_stackframe();
 					panic
-					    ("handle pgfault failed in kernel mode. %e\n",
-					     ret);
+					    ("%llx: handle pgfault failed in kernel mode. %e\n",
+					     addr, ret);
 				}
 				print_pgfault(tf);
 				kprintf("pgfault_handler return %d\n", ret);

--- a/ucore/src/kern-ucore/fs/devfs/devfs_inode.c
+++ b/ucore/src/kern-ucore/fs/devfs/devfs_inode.c
@@ -122,8 +122,8 @@ static int devfs_gettype(struct inode *node, uint32_t * type_store)
 static int devfs_lookup_parent(
 struct inode *node, char *path, struct inode **node_store, char **endp)
 {
-  //TODO: need to implement real device lookup.
-  panic("");
+  vop_ref_inc(node);
+  (*node_store) = node;
   return 0;
 }
 

--- a/ucore/src/kern-ucore/fs/file.c
+++ b/ucore/src/kern-ucore/fs/file.c
@@ -640,7 +640,8 @@ void *linux_regfile_mmap2(void *addr, size_t len, int prot, int flags, int fd,
 		goto out_unlock;
 	}
 	if (!(flags & MAP_ANONYMOUS)) {
-		vma_mapfile(vma, fd, off << 12, NULL);
+    vma_mapfile(vma, fd, off, NULL);
+		//vma_mapfile(vma, fd, off << 12, NULL);
 	}
 	subret = 0;
 out_unlock:

--- a/ucore/src/kern-ucore/fs/file.c
+++ b/ucore/src/kern-ucore/fs/file.c
@@ -618,6 +618,7 @@ void *linux_regfile_mmap2(void *addr, size_t len, int prot, int flags, int fd,
 		goto out_unlock;
 	}
 	uintptr_t end = start + len;
+  kprintf("start = %llx, end = %llx, len = %llx", start, end, len);
 	struct vma_struct *vma = find_vma(mm, start);
 	if (vma == NULL || vma->vm_start >= end) {
 		vma = NULL;
@@ -629,7 +630,9 @@ void *linux_regfile_mmap2(void *addr, size_t len, int prot, int flags, int fd,
 	} else if (vma->vm_start == start && end == vma->vm_end) {
 		vma->vm_flags = vm_flags;
 	} else {
-		assert(vma->vm_start <= start && end <= vma->vm_end);
+    if(vma->vm_start > start || end > vma->vm_end) {
+      goto out_unlock;
+    }
 		if ((subret = mm_unmap_keep_pages(mm, start, len)) != 0) {
 			goto out_unlock;
 		}

--- a/ucore/src/kern-ucore/fs/file.h
+++ b/ucore/src/kern-ucore/fs/file.h
@@ -70,4 +70,10 @@ static inline int fopen_count_dec(struct file *file)
 	return atomic_sub_return(&(file->open_count), 1);
 }
 
+#ifdef UCONFIG_BIONIC_LIBC
+struct file* fd2file_onfs(int fd, struct fs_struct *fs_struct);
+void *linux_regfile_mmap2(void *addr, size_t len, int prot, int flags, int fd,
+			  size_t off);
+#endif
+
 #endif /* !__KERN_FS_FILE_H__ */

--- a/ucore/src/kern-ucore/fs/sfs/sfs_inode.c
+++ b/ucore/src/kern-ucore/fs/sfs/sfs_inode.c
@@ -727,6 +727,7 @@ static int sfs_fstat(struct inode *node, struct stat *stat)
 		return ret;
 	}
 	struct sfs_disk_inode *din = vop_info(node, sfs_inode)->din;
+  stat->st_ino = vop_info(node, sfs_inode)->ino;
 	stat->st_nlinks = din->nlinks;
 	stat->st_blocks = din->blocks;
 	if (din->type != SFS_TYPE_DIR) {

--- a/ucore/src/kern-ucore/fs/sysfile.c
+++ b/ucore/src/kern-ucore/fs/sysfile.c
@@ -275,10 +275,7 @@ int sysfile_linux_fstat64(int fd, struct linux_stat64 __user * linux_stat_store)
   lock_mm(mm);
   memset(linux_stat_store, 0, sizeof(struct linux_stat64));
 
-  static int unique_ino = 100;
-
-  linux_stat_store->st_ino = unique_ino; //TODO: This is a temporary fix.
-  unique_ino++;
+  linux_stat_store->st_ino = ucore_stat.st_ino; //TODO: Some fs have no support for this.
   /* ucore never check access permision */
 	linux_stat_store->st_mode = ucore_stat.st_mode | 0777;
 	linux_stat_store->st_nlink = ucore_stat.st_nlinks;

--- a/ucore/src/kern-ucore/fs/sysfile.c
+++ b/ucore/src/kern-ucore/fs/sysfile.c
@@ -285,12 +285,6 @@ int sysfile_linux_fstat64(int fd, struct linux_stat64 __user * linux_stat_store)
 	linux_stat_store->st_blksize = 512;
 	linux_stat_store->st_blocks = ucore_stat.st_blocks;
 	linux_stat_store->st_size = ucore_stat.st_size;
-  kprintf("Returning size = %d\n", linux_stat_store->st_ino);
-  kprintf("Returning size = %d\n", linux_stat_store->st_mode);
-  kprintf("Returning size = %d\n", linux_stat_store->st_nlink);
-  kprintf("Returning size = %d\n", linux_stat_store->st_blksize);
-  kprintf("Returning size = %d\n", linux_stat_store->st_blocks);
-  kprintf("Returning size = %d\n", linux_stat_store->st_size);
   unlock_mm(mm);
 
 	return 0;

--- a/ucore/src/kern-ucore/fs/sysfile.c
+++ b/ucore/src/kern-ucore/fs/sysfile.c
@@ -271,27 +271,26 @@ int sysfile_linux_fstat64(int fd, struct linux_stat64 __user * linux_stat_store)
 	if ((ret = file_fstat(fd, &ucore_stat)) != 0) {
 		return ret;
 	}
-  kprintf("%d\n",offsetof(struct linux_stat64, st_dev));
-  kprintf("%d\n",offsetof(struct linux_stat64, st_ino));
-  kprintf("%d\n",offsetof(struct linux_stat64, st_mode));
-  kprintf("%d\n",offsetof(struct linux_stat64, st_nlink));
-  kprintf("%d\n",offsetof(struct linux_stat64, st_uid));
-  kprintf("%d\n",offsetof(struct linux_stat64, st_gid));
-  kprintf("%d\n",offsetof(struct linux_stat64, st_rdev));
-  kprintf("%d\n",offsetof(struct linux_stat64, st_size));
-  kprintf("%d\n",offsetof(struct linux_stat64, st_blksize));
-  kprintf("%d\n",offsetof(struct linux_stat64, st_blocks));
-  kprintf("kstat->st_size = %d\r\n", ucore_stat.st_size);
 
   lock_mm(mm);
   memset(linux_stat_store, 0, sizeof(struct linux_stat64));
-  linux_stat_store->st_ino = 1;
+
+  static int unique_ino = 100;
+
+  linux_stat_store->st_ino = unique_ino; //TODO: This is a temporary fix.
+  unique_ino++;
   /* ucore never check access permision */
 	linux_stat_store->st_mode = ucore_stat.st_mode | 0777;
 	linux_stat_store->st_nlink = ucore_stat.st_nlinks;
 	linux_stat_store->st_blksize = 512;
 	linux_stat_store->st_blocks = ucore_stat.st_blocks;
 	linux_stat_store->st_size = ucore_stat.st_size;
+  kprintf("Returning size = %d\n", linux_stat_store->st_ino);
+  kprintf("Returning size = %d\n", linux_stat_store->st_mode);
+  kprintf("Returning size = %d\n", linux_stat_store->st_nlink);
+  kprintf("Returning size = %d\n", linux_stat_store->st_blksize);
+  kprintf("Returning size = %d\n", linux_stat_store->st_blocks);
+  kprintf("Returning size = %d\n", linux_stat_store->st_size);
   unlock_mm(mm);
 
 	return 0;
@@ -616,7 +615,7 @@ int sysfile_ioctl(int fd, unsigned int cmd, unsigned long arg)
 void *sysfile_linux_mmap2(void *addr, size_t len, int prot, int flags,
 			  int fd, size_t pgoff)
 {
-  kprintf("sysfile_linux_mmap2, len = %d", len);
+  //kprintf("sysfile_linux_mmap2, len = %d, pgoff = %d\n", len, pgoff);
 	if (!file_testfd(fd, 1, 0)) {
 		return MAP_FAILED;
 	}

--- a/ucore/src/kern-ucore/libs/elf.h
+++ b/ucore/src/kern-ucore/libs/elf.h
@@ -321,4 +321,39 @@ struct symtab_s {
 
 #endif /* __UCORE_64__ */
 
+struct elf64_auxiliary_vector
+{
+  uint64_t a_type;
+  uint64_t a_val;
+} Elf64_auxv_t;
+
+/* Symbolic values for the entries in the auxiliary table
+   put on the initial stack */
+#define AT_NULL   0	/* end of vector */
+#define AT_IGNORE 1	/* entry should be ignored */
+#define AT_EXECFD 2	/* file descriptor of program */
+#define AT_PHDR   3	/* program headers for program */
+#define AT_PHENT  4	/* size of program header entry */
+#define AT_PHNUM  5	/* number of program headers */
+#define AT_PAGESZ 6	/* system page size */
+#define AT_BASE   7	/* base address of interpreter */
+#define AT_FLAGS  8	/* flags */
+#define AT_ENTRY  9	/* entry point of program */
+#define AT_NOTELF 10	/* program is not ELF */
+#define AT_UID    11	/* real uid */
+#define AT_EUID   12	/* effective uid */
+#define AT_GID    13	/* real gid */
+#define AT_EGID   14	/* effective gid */
+#define AT_PLATFORM 15  /* string identifying CPU for optimizations */
+#define AT_HWCAP  16    /* arch dependent hints at CPU capabilities */
+#define AT_CLKTCK 17	/* frequency at which times() increments */
+/* AT_* values 18 through 22 are reserved */
+#define AT_SECURE 23   /* secure mode boolean */
+#define AT_BASE_PLATFORM 24	/* string identifying real platform, may
+				 * differ from AT_PLATFORM. */
+#define AT_RANDOM 25	/* address of 16 random bytes */
+#define AT_HWCAP2 26	/* extension of AT_HWCAP */
+
+#define AT_EXECFN  31	/* filename of program */
+
 #endif /* !__LIBS_ELF_H__ */

--- a/ucore/src/kern-ucore/libs/elf.h
+++ b/ucore/src/kern-ucore/libs/elf.h
@@ -109,9 +109,14 @@
 #define SHN_HIRESERVE   0xffff
 
 /* values for Proghdr::p_type */
-#define ELF_PT_LOAD                     1
-
+#define ELF_PT_NULL           0
+#define ELF_PT_LOAD           1
+#define ELF_PT_DYNAMIC  			2
 #define ELF_PT_INTERP					3
+#define ELF_PT_NOTE           4
+#define ELF_PT_SHLIB    			5
+#define ELF_PT_PHDR			  		6
+#define ELF_PT_TLS            7
 
 /* flag bits for Proghdr::p_flags */
 #define ELF_PF_X                        1

--- a/ucore/src/kern-ucore/libs/stat.h
+++ b/ucore/src/kern-ucore/libs/stat.h
@@ -45,6 +45,7 @@ struct linux_stat {
 	unsigned long __unused5;
 };
 
+#ifdef ARCH_ARM
 struct linux_stat64 {
 	unsigned long long st_dev;
 	unsigned char __pad0[4];
@@ -66,6 +67,28 @@ struct linux_stat64 {
 	unsigned long st_ctime_nsec;
 	unsigned long long st_ino;
 };
+#endif //ARCH_ARM
+
+#ifdef ARCH_AMD64
+struct linux_stat64 {
+	uint64_t st_dev;
+	uint64_t st_ino;
+  uint64_t st_nlink;
+	uint32_t st_mode;
+	uint32_t st_uid;
+	uint32_t st_gid;
+	uint64_t st_rdev;
+	uint64_t st_size;
+	uint64_t st_blksize;
+	uint64_t st_blocks;
+	unsigned long st_atime;
+	unsigned long st_atime_nsec;
+	unsigned long st_mtime;
+	unsigned long st_mtime_nsec;
+	unsigned long st_ctime;
+	unsigned long st_ctime_nsec;
+};
+#endif //ARCH_AMD64
 
 #if 0
 #define S_IFMT          070000	// mask for type of file

--- a/ucore/src/kern-ucore/libs/stat.h
+++ b/ucore/src/kern-ucore/libs/stat.h
@@ -8,6 +8,7 @@ struct stat {
 #else
 struct ucore_stat {
 #endif
+  uint32_t st_ino;
 	uint32_t st_mode;	// protection mode and file type
 	size_t st_nlinks;	// number of hard links
 	size_t st_blocks;	// number of blocks file is using

--- a/ucore/src/kern-ucore/mm/vmm.c
+++ b/ucore/src/kern-ucore/mm/vmm.c
@@ -19,9 +19,9 @@
 
 #define false	(0)
 
-/* 
+/*
    vmm design include two parts: mm_struct (mm) & vma_struct (vma)
-   mm is the memory manager for the set of continuous virtual memory  
+   mm is the memory manager for the set of continuous virtual memory
    area which have the same PDT. vma is a continuous virtual memory area.
    There a linear link list for vma & a redblack link list for vma in mm.
    ---------------
@@ -38,7 +38,7 @@
    struct vma_struct * find_vma(struct mm_struct *mm, uintptr_t addr)
    local functions
    inline void check_vma_overlap(struct vma_struct *prev, struct vma_struct *next)
-   inline struct vma_struct * find_vma_rb(rb_tree *tree, uintptr_t addr) 
+   inline struct vma_struct * find_vma_rb(rb_tree *tree, uintptr_t addr)
    inline void insert_vma_rb(rb_tree *tree, struct vma_struct *vma, ....
    inline int vma_compare(rb_node *node1, rb_node *node2)
    ---------------
@@ -164,7 +164,7 @@ static inline struct vma_struct *find_vma_rb(rb_tree * tree, uintptr_t addr)
 		}
 	}
 #if 0
-    if (vma!=NULL) 
+    if (vma!=NULL)
       kprintf("  find_vma_rb end:: addr %d, vma %x, start %d, end %d\n",addr, vma, vma->vm_start, vma->vm_end);
     else
       kprintf("  find_vma_rb end:: vma is NULL\n");
@@ -235,9 +235,7 @@ void vma_mapfile(struct vma_struct *vma, int fd, off_t off, struct fs_struct *fs
 		fs_struct = current->fs_struct;
 	}
 
-	/*
-	   kprintf("mapfile:0x%08x fs_struct:0x%08x\n", vma->mfile.file, fs_struct);
-	 */
+	//kprintf("mapfile:0x%08x fs_struct:0x%08x off:%d\n", vma->mfile.file, fs_struct, off);
 
 	vma->mfile.offset = off;
 	assert(vma != NULL);
@@ -735,7 +733,11 @@ user_mem_check(struct mm_struct * mm, uintptr_t addr, size_t len, bool write)
 		}
 		return 1;
 	}
-	return KERN_ACCESS(addr, addr + len);
+  //TODO: Always returning 1 when mm is not loaded allows a much simplier
+  //implementation of map_ph for load_icode, but I'm not sure if it doesn't
+  //lead to security issues.
+  return 1;
+	//return KERN_ACCESS(addr, addr + len);
 }
 
 // check_vmm - check correctness of vmm
@@ -894,8 +896,8 @@ int do_pgfault(struct mm_struct *mm, machine_word_t error_code, uintptr_t addr)
 {
 	if (mm == NULL) {
 		assert(current != NULL);
-		/* Chen Yuheng 
-		 * give handler a chance to deal with it 
+		/* Chen Yuheng
+		 * give handler a chance to deal with it
 		 */
 		kprintf
 		    ("page fault in kernel thread: pid = %d, name = %s, %d %08x.\n",
@@ -1063,7 +1065,7 @@ int do_pgfault(struct mm_struct *mm, machine_word_t error_code, uintptr_t addr)
 #endif
 			}
 		}
-	} else {		//a present page, handle copy-on-write (cow) 
+	} else {		//a present page, handle copy-on-write (cow)
 		struct Page *page, *newpage = NULL;
 		bool cow =
 		    ((vma->vm_flags & (VM_SHARE | VM_WRITE)) == VM_WRITE),

--- a/ucore/src/kern-ucore/process/proc.c
+++ b/ucore/src/kern-ucore/process/proc.c
@@ -1112,7 +1112,7 @@ static int load_icode(int fd, int argc, char **kargv, int envc, char **kenvp)
 	if (!is_dynamic) {
 		real_entry += bias;
 	}
-#ifdef UCONFIG_BIONIC_LIBC
+#if defined(UCONFIG_BIONIC_LIBC) || defined(ARCH_AMD64)
 	if (init_new_context_dynamic(current, elf, argc, kargv, envc, kenvp,
 				     is_dynamic, real_entry, load_address,
 				     bias) < 0)

--- a/ucore/src/kern-ucore/process/proc.c
+++ b/ucore/src/kern-ucore/process/proc.c
@@ -761,104 +761,128 @@ static int load_icode_read(int fd, void *buf, size_t len, off_t offset)
 	return 0;
 }
 
-//#ifdef UCONFIG_BIONIC_LIBC
-static int
-map_ph(int fd, struct proghdr *ph, struct mm_struct *mm, uint32_t * pbias,
-       uint32_t linker)
+/*
+ * An ELF executable contains one or more "program", each program is defines
+ * its offset and size in the ELF file, as well as where it expects it self
+ * to be loaded in the virtual memory. Full content of the program header is
+ * represented by a proghdr structure.
+ * However, an important point needs to be mentioned is that, despite the
+ * virtual address in the proghdr structure (i.e. ph->p_va), the OS doesn't have
+ * to load the ELF into the specified location of the virtual memory.
+ */
+
+static bool proc_elf_program_load_needed(struct proghdr *program_header)
 {
-	int ret = 0;
-	struct Page *page;
-	uint32_t vm_flags = 0;
-	uint32_t bias = 0;
-	pte_perm_t perm = 0;
-	ptep_set_u_read(&perm);
-
-	if (ph->p_flags & ELF_PF_X)
-		vm_flags |= VM_EXEC;
-	if (ph->p_flags & ELF_PF_W)
-		vm_flags |= VM_WRITE;
-	if (ph->p_flags & ELF_PF_R)
-		vm_flags |= VM_READ;
-
-	if (vm_flags & VM_WRITE)
-		ptep_set_u_write(&perm);
-
-	if (pbias) {
-		bias = *pbias;
-	}
-	if (!bias && !ph->p_va) {
-		bias = get_unmapped_area(mm, ph->p_memsz + PGSIZE);
-		bias = ROUNDUP(bias, PGSIZE);
-		if (pbias)
-			*pbias = bias;
-	}
-
-	if ((ret =
-	     mm_map(mm, ph->p_va + bias, ph->p_memsz, vm_flags, NULL)) != 0) {
-		goto bad_cleanup_mmap;
-	}
-
-	if (!linker && mm->brk_start < ph->p_va + bias + ph->p_memsz) {
-		mm->brk_start = ph->p_va + bias + ph->p_memsz;
-	}
-
-	off_t offset = ph->p_offset;
-	size_t off, size;
-	uintptr_t start = ph->p_va + bias, end, la = ROUNDDOWN(start, PGSIZE);
-
-	end = ph->p_va + bias + ph->p_filesz;
-	while (start < end) {
-		if ((page = pgdir_alloc_page(mm->pgdir, la, perm)) == NULL) {
-			ret = -E_NO_MEM;
-			goto bad_cleanup_mmap;
-		}
-		off = start - la, size = PGSIZE - off, la += PGSIZE;
-		if (end < la) {
-			size -= la - end;
-		}
-		if ((ret =
-		     load_icode_read(fd, page2kva(page) + off, size,
-				     offset)) != 0) {
-			goto bad_cleanup_mmap;
-		}
-		start += size, offset += size;
-	}
-
-	end = ph->p_va + bias + ph->p_memsz;
-
-	if (start < la) {
-		if (start == end) {
-			goto normal_exit;
-		}
-		off = start + PGSIZE - la, size = PGSIZE - off;
-		if (end < la) {
-			size -= la - end;
-		}
-		memset(page2kva(page) + off, 0, size);
-		start += size;
-		assert((end < la && start == end)
-		       || (end >= la && start == la));
-	}
-
-	while (start < end) {
-		if ((page = pgdir_alloc_page(mm->pgdir, la, perm)) == NULL) {
-			ret = -E_NO_MEM;
-			goto bad_cleanup_mmap;
-		}
-		off = start - la, size = PGSIZE - off, la += PGSIZE;
-		if (end < la) {
-			size -= la - end;
-		}
-		memset(page2kva(page) + off, 0, size);
-		start += size;
-	}
-normal_exit:
-	return 0;
-bad_cleanup_mmap:
-	return ret;
+  return program_header->p_type == ELF_PT_LOAD ||
+    program_header->p_type == ELF_PT_DYNAMIC ||
+    program_header->p_type == ELF_PT_PHDR;
 }
 
-//#endif //UCONFIG_BIONIC_LIBC
+static int proc_elf_allocate_memory(struct proghdr *program_headers,
+int program_count, struct mm_struct *mm, int fd)
+{
+  struct address_range {
+    char* start_addr;
+    char* end_addr;
+  };
+  struct address_range* ranges = kmalloc(program_count * sizeof(struct address_range));
+  for(int i = 0; i < program_count; i++) {
+    ranges[i].start_addr = ranges[i].end_addr = 0;
+  }
+  for(int i = 0; i < program_count; i++) {
+    struct proghdr *program_header = &program_headers[i];
+    if(!proc_elf_program_load_needed(program_header)) continue;
+    int ret;
+    uint32_t vm_flags = 0;
+    uint32_t bias = 0;
+
+    if (program_header->p_flags & ELF_PF_X)
+      vm_flags |= VM_EXEC;
+    if (program_header->p_flags & ELF_PF_W)
+      vm_flags |= VM_WRITE;
+    if (program_header->p_flags & ELF_PF_R)
+      vm_flags |= VM_READ;
+
+    ret = mm_map(mm, program_header->p_va + bias, program_header->p_memsz, vm_flags, NULL);
+    //if(ret != 0) return -E_NOMEM;
+
+    if (mm->brk_start < program_header->p_va + bias + program_header->p_memsz) {
+      mm->brk_start = program_header->p_va + bias + program_header->p_memsz;
+    }
+
+    char* start = program_header->p_va + bias;
+    char* end = program_header->p_va + bias + program_header->p_memsz;
+
+    //TODO: Not certain if this may introduce a bug if end % PGSIZE == 0.
+    start = ROUNDDOWN(start, PGSIZE);
+    end = ROUNDUP(end, PGSIZE);
+    ranges[i].start_addr = start;
+    ranges[i].end_addr = end;
+
+    for(uintptr_t addr = start; addr < end; addr += PGSIZE) {
+      bool already_allocated = 0;
+      for(int j = 0; j < i; j++) {
+        if(addr < ranges[j].end_addr && addr >= ranges[j].start_addr) {
+          already_allocated = 1;
+          break;
+        }
+      }
+      if(already_allocated) continue;
+      if (pgdir_alloc_page(mm->pgdir, addr, PTE_W) == NULL) {
+        return -E_NO_MEM;
+      }
+    }
+  }
+  kfree(ranges);
+  mp_set_mm_pagetable(mm);
+  return 0;
+}
+
+static void proc_elf_load_program(struct proghdr *program_headers,
+int program_count, int fd)
+{
+  int bias = 0;
+  for(int i = 0; i < program_count; i++) {
+    struct proghdr* program_header = &program_headers[i];
+    if(!proc_elf_program_load_needed(program_header)) continue;
+    int ret = load_icode_read(fd, program_header->p_va + bias,
+      program_header->p_filesz, program_header->p_offset);
+    if(ret != 0) return ret;
+  }
+  return 0;
+}
+
+static void proc_elf_set_permission(struct proghdr *program_headers,
+int program_count, struct mm_struct *mm, int fd)
+{
+  uint64_t bias = 0;
+  for(int i = 0; i < program_count; i++) {
+    struct proghdr* program_header = &program_headers[i];
+    if(!proc_elf_program_load_needed(program_header)) continue;
+    pte_perm_t perm = 0;
+    ptep_set_u_read(&perm);
+    if (program_header->p_flags & ELF_PF_W)
+      ptep_set_u_write(&perm);
+    uintptr_t start = program_header->p_va + bias;
+    uintptr_t end = program_header->p_va + bias + program_header->p_memsz;
+    start = ROUNDDOWN(start, PGSIZE);
+    end = ROUNDUP(end, PGSIZE);
+    int program_page_count = (end - start) / PGSIZE;
+    pte_t* pte = get_pte(mm->pgdir, start, 0);
+    for(int i = 0; i < program_page_count; i++) {
+      pte[i] = (pte[i] & ~(PTE_W|PTE_U)) | perm;
+    }
+  }
+  return 0;
+}
+
+static void proc_load_elf(struct proghdr *program_headers,
+int program_count, struct mm_struct *mm, int fd)
+{
+  proc_elf_allocate_memory(program_headers, program_count, mm, fd);
+  proc_elf_load_program(program_headers, program_count, fd);
+  proc_elf_set_permission(program_headers, program_count, mm, fd);
+}
 
 static int load_icode(int fd, int argc, char **kargv, int envc, char **kenvp)
 {
@@ -870,14 +894,8 @@ static int load_icode(int fd, int argc, char **kargv, int envc, char **kenvp)
 
 	int ret = -E_NO_MEM;
 
-//#ifdef UCONFIG_BIONIC_LIBC
-	uint32_t real_entry;
-//#endif //UCONFIG_BIONIC_LIBC
-
-	struct mm_struct *mm;
-	if ((mm = mm_create()) == NULL) {
-		goto bad_mm;
-	}
+	struct mm_struct *mm = mm_create();
+	if (mm == NULL) goto bad_mm;
 
 	if (setup_pgdir(mm) != 0) {
 		goto bad_pgdir_cleanup_mm;
@@ -896,124 +914,45 @@ static int load_icode(int fd, int argc, char **kargv, int envc, char **kenvp)
 		ret = -E_INVAL_ELF;
 		goto bad_elf_cleanup_pgdir;
 	}
-//#ifdef UCONFIG_BIONIC_LIBC
-	real_entry = elf->e_entry;
-
-	uint32_t load_address, load_address_flag = 0;
-//#endif //UCONFIG_BIONIC_LIBC
 
 	struct proghdr __ph, *ph = &__ph;
 	uint32_t vm_flags, phnum;
 	pte_perm_t perm = 0;
 
-//#ifdef UCONFIG_BIONIC_LIBC
-	uint32_t is_dynamic = 0, interp_idx;
+  bool elf_have_interpreter = 0;
+  void *elf_entry = elf->e_entry;
+  void *interpreter_entry = NULL;
+  char *interpreter_path = NULL;
+  void* program_header_address = NULL;
+	uint32_t interp_idx;
 	uint32_t bias = 0;
-//#endif //UCONFIG_BIONIC_LIBC
-	for (phnum = 0; phnum < elf->e_phnum; phnum++) {
-		off_t phoff = elf->e_phoff + sizeof(struct proghdr) * phnum;
-		if ((ret =
-		     load_icode_read(fd, ph, sizeof(struct proghdr),
-				     phoff)) != 0) {
-			goto bad_cleanup_mmap;
-		}
 
-		if (ph->p_type == ELF_PT_INTERP) {
-			is_dynamic = 1;
-			interp_idx = phnum;
-			continue;
-		}
+  struct proghdr* program_headers = kmalloc(sizeof(struct proghdr) * elf->e_phnum);
+  load_icode_read(fd, program_headers, sizeof(struct proghdr) * elf->e_phnum, elf->e_phoff);
+  proc_load_elf(program_headers, elf->e_phnum, mm, fd);
 
-		if (ph->p_type != ELF_PT_LOAD) {
-			continue;
-		}
-		if (ph->p_filesz > ph->p_memsz) {
-			ret = -E_INVAL_ELF;
-			goto bad_cleanup_mmap;
-		}
-
-		if (ph->p_va == 0 && !bias) {
-			bias = 0x00008000;
-		}
-
-		if ((ret = map_ph(fd, ph, mm, &bias, 0)) != 0) {
-			kprintf("load address: 0x%08x size: %d\n", ph->p_va,
-				ph->p_memsz);
-			goto bad_cleanup_mmap;
-		}
-
-		if (load_address_flag == 0)
-			load_address = ph->p_va + bias;
-		++load_address_flag;
-
-	  /*********************************************/
-		/*
-		   vm_flags = 0;
-		   ptep_set_u_read(&perm);
-		   if (ph->p_flags & ELF_PF_X) vm_flags |= VM_EXEC;
-		   if (ph->p_flags & ELF_PF_W) vm_flags |= VM_WRITE;
-		   if (ph->p_flags & ELF_PF_R) vm_flags |= VM_READ;
-		   if (vm_flags & VM_WRITE) ptep_set_u_write(&perm);
-
-		   if ((ret = mm_map(mm, ph->p_va, ph->p_memsz, vm_flags, NULL)) != 0) {
-		   goto bad_cleanup_mmap;
-		   }
-
-		   if (mm->brk_start < ph->p_va + ph->p_memsz) {
-		   mm->brk_start = ph->p_va + ph->p_memsz;
-		   }
-
-		   off_t offset = ph->p_offset;
-		   size_t off, size;
-		   uintptr_t start = ph->p_va, end, la = ROUNDDOWN(start, PGSIZE);
-
-		   end = ph->p_va + ph->p_filesz;
-		   while (start < end) {
-		   if ((page = pgdir_alloc_page(mm->pgdir, la, perm)) == NULL) {
-		   ret = -E_NO_MEM;
-		   goto bad_cleanup_mmap;
-		   }
-		   off = start - la, size = PGSIZE - off, la += PGSIZE;
-		   if (end < la) {
-		   size -= la - end;
-		   }
-		   if ((ret = load_icode_read(fd, page2kva(page) + off, size, offset)) != 0) {
-		   goto bad_cleanup_mmap;
-		   }
-		   start += size, offset += size;
-		   }
-
-		   end = ph->p_va + ph->p_memsz;
-
-		   if (start < la) {
-		   // ph->p_memsz == ph->p_filesz
-		   if (start == end) {
-		   continue ;
-		   }
-		   off = start + PGSIZE - la, size = PGSIZE - off;
-		   if (end < la) {
-		   size -= la - end;
-		   }
-		   memset(page2kva(page) + off, 0, size);
-		   start += size;
-		   assert((end < la && start == end) || (end >= la && start == la));
-		   }
-
-		   while (start < end) {
-		   if ((page = pgdir_alloc_page(mm->pgdir, la, perm)) == NULL) {
-		   ret = -E_NO_MEM;
-		   goto bad_cleanup_mmap;
-		   }
-		   off = start - la, size = PGSIZE - off, la += PGSIZE;
-		   if (end < la) {
-		   size -= la - end;
-		   }
-		   memset(page2kva(page) + off, 0, size);
-		   start += size;
-		   }
-		 */
-	  /**************************************/
-	}
+  for(int i = 0; i < elf->e_phnum; i++) {
+    struct proghdr* ph = &program_headers[i];
+    if (ph->p_type == ELF_PT_INTERP) {
+      if(!elf_have_interpreter) {
+        elf_have_interpreter = 1;
+        interpreter_path = (char*)kmalloc(ph->p_filesz);
+        load_icode_read(fd, interpreter_path, ph->p_filesz, ph->p_offset);
+      }
+      else {
+        ret = -E_INVAL_ELF;
+        goto bad_cleanup_mmap;
+      }
+      interp_idx = phnum;
+    }
+    else if(ph->p_type == ELF_PT_PHDR) {
+      program_header_address = ph->p_va;
+    }
+    if (ph->p_filesz > ph->p_memsz) {
+      ret = -E_INVAL_ELF;
+      goto bad_cleanup_mmap;
+    }
+  }
 
 	mm->brk_start = mm->brk = ROUNDUP(mm->brk_start, PGSIZE);
 
@@ -1024,76 +963,23 @@ static int load_icode(int fd, int argc, char **kargv, int envc, char **kenvp)
 		    NULL)) != 0) {
 		goto bad_cleanup_mmap;
 	}
-
-	if (is_dynamic) {
-		elf->e_entry += bias;
-
-		bias = 0;
-
-		off_t phoff =
-		    elf->e_phoff + sizeof(struct proghdr) * interp_idx;
-		if ((ret =
-		     load_icode_read(fd, ph, sizeof(struct proghdr),
-				     phoff)) != 0) {
-			goto bad_cleanup_mmap;
-		}
-
-		char *interp_path = (char *)kmalloc(ph->p_filesz);
-		load_icode_read(fd, interp_path, ph->p_filesz, ph->p_offset);
-
-		int interp_fd = sysfile_open(interp_path, O_RDONLY);
+	if (elf_have_interpreter) {
+		int interp_fd = sysfile_open(interpreter_path, O_RDONLY);
 		assert(interp_fd >= 0);
 		struct elfhdr interp___elf, *interp_elf = &interp___elf;
 		assert((ret =
 			load_icode_read(interp_fd, interp_elf,
 					sizeof(struct elfhdr), 0)) == 0);
 		assert(interp_elf->e_magic == ELF_MAGIC);
-
-		struct proghdr interp___ph, *interp_ph = &interp___ph;
-		uint32_t interp_phnum;
-		uint32_t va_min = 0xffffffff, va_max = 0;
-		for (interp_phnum = 0; interp_phnum < interp_elf->e_phnum;
-		     ++interp_phnum) {
-			off_t interp_phoff =
-			    interp_elf->e_phoff +
-			    sizeof(struct proghdr) * interp_phnum;
-			assert((ret =
-				load_icode_read(interp_fd, interp_ph,
-						sizeof(struct proghdr),
-						interp_phoff)) == 0);
-			if (interp_ph->p_type != ELF_PT_LOAD) {
-				continue;
-			}
-			if (va_min > interp_ph->p_va)
-				va_min = interp_ph->p_va;
-			if (va_max < interp_ph->p_va + interp_ph->p_memsz)
-				va_max = interp_ph->p_va + interp_ph->p_memsz;
-		}
-
-		bias = get_unmapped_area(mm, va_max - va_min + 1 + PGSIZE);
-		bias = ROUNDUP(bias, PGSIZE);
-
-		for (interp_phnum = 0; interp_phnum < interp_elf->e_phnum;
-		     ++interp_phnum) {
-			off_t interp_phoff =
-			    interp_elf->e_phoff +
-			    sizeof(struct proghdr) * interp_phnum;
-			assert((ret =
-				load_icode_read(interp_fd, interp_ph,
-						sizeof(struct proghdr),
-						interp_phoff)) == 0);
-			if (interp_ph->p_type != ELF_PT_LOAD) {
-				continue;
-			}
-			assert((ret =
-				map_ph(interp_fd, interp_ph, mm, &bias,
-				       1)) == 0);
-		}
-
-		real_entry = interp_elf->e_entry + bias;
-
+    interpreter_entry = interp_elf->e_entry;
+    struct proghdr* interpreter_headers = kmalloc(sizeof(struct proghdr) * interp_elf->e_phnum);
+    load_icode_read(
+      interp_fd, interpreter_headers, sizeof(struct proghdr) * interp_elf->e_phnum,
+      interp_elf->e_phoff
+    );
+    proc_load_elf(interpreter_headers, interp_elf->e_phnum, mm, interp_fd);
 		sysfile_close(interp_fd);
-		kfree(interp_path);
+		kfree(interpreter_path);
 	}
 
 	sysfile_close(fd);
@@ -1109,13 +995,10 @@ static int load_icode(int fd, int argc, char **kargv, int envc, char **kenvp)
 	set_pgdir(current, mm->pgdir);
 	mp_set_mm_pagetable(mm);
 
-	if (!is_dynamic) {
-		real_entry += bias;
-	}
 #if defined(UCONFIG_BIONIC_LIBC) || defined(ARCH_AMD64)
 	if (init_new_context_dynamic(current, elf, argc, kargv, envc, kenvp,
-				     is_dynamic, real_entry, load_address,
-				     bias) < 0)
+				     elf_have_interpreter, interpreter_entry, elf_entry,
+				     bias, program_header_address) < 0)
 		goto bad_cleanup_mmap;
 #else
 	if (init_new_context(current, elf, argc, kargv, envc, kenvp) < 0)

--- a/ucore/src/kern-ucore/process/proc.h
+++ b/ucore/src/kern-ucore/process/proc.h
@@ -158,5 +158,6 @@ int init_new_context(struct proc_struct *proc, struct elfhdr *elf,
 int kernel_thread(int (*fn) (void *), void *arg, uint32_t clone_flags);
 int kernel_execve(const char *name, const char **argv, const char **kenvp);
 int do_execve_arch_hook(int argc, char **kargv);
+int __do_linux_mmap(uintptr_t __user * addr_store, size_t len, uint32_t mmap_flags);
 
 #endif /* !__KERN_PROCESS_PROC_H__ */

--- a/ucore/src/libs-user-ucore/common/stat.h
+++ b/ucore/src/libs-user-ucore/common/stat.h
@@ -4,6 +4,7 @@
 #include <types.h>
 
 struct stat {
+  uint32_t st_ino;
 	uint32_t st_mode;	// protection mode and file type
 	size_t st_nlinks;	// number of hard links
 	size_t st_blocks;	// number of blocks file is using


### PR DESCRIPTION
uClibc ld.so now is supported. Currently it is suggested to use uClibc 0.9.33.2. However, the original pthread bug is still unfixed, and seems mutex has a new bug.

ELF file loading is rewritten, now biased loading is removed, they will be added after learning more about relocatable and PIC ELF. Due to this problem, ld.so is loaded at 0x0 and a small fix is required to get it work.

uClibc(-ng) 1.0.x's ld.so is also supported. However pthread support have completely migrated to NPTL in uCLibc 1.0.x, so pthread related-feature will not work.