### PR TITLE
Incompleted implant of print_stackframe.

### DIFF
--- a/ucore/src/kern-ucore/arch/amd64/debug/kdebug.c
+++ b/ucore/src/kern-ucore/arch/amd64/debug/kdebug.c
@@ -6,8 +6,36 @@
 #include <vmm.h>
 #include <kdebug.h>
 #include <kio.h>
+#include <stab.h>
+#include <proc.h>
 
 #define STACKFRAME_DEPTH 20
+
+// To implent:
+//   debuginfo_rip(debuginfo_eip)
+// To check:
+//   stab_binsearch()
+struct ripdebuginfo {
+	const char *rip_file;	// source code filename for rip
+	int rip_line;		// source code line number for rip
+	const char *rip_fn_name;	// name of function containing rip
+	int rip_fn_namelen;	// length of function's name
+	uintptr_t rip_fn_addr;	// start address of function
+	int rip_fn_narg;	// number of function arguments
+};
+
+/* user STABS data structure  */
+struct userstabdata {
+	const struct stab *stabs;
+	const struct stab *stab_end;
+	const char *stabstr;
+	const char *stabstr_end;
+};
+
+extern const struct stab __STAB_BEGIN__[];	// beginning of stabs table
+extern const struct stab __STAB_END__[];	// end of stabs table
+extern const char __STABSTR_BEGIN__[];	// beginning of string table
+extern const char __STABSTR_END__[];	// end of string table
 
 /* *
  * print_kerninfo - print the information about kernel, including the location
@@ -44,12 +72,287 @@ static uint64_t read_rip(void)
  * */
 void print_stackframe(void)
 {
+	kprintf("in print_stackframe\r\n");
 	uint64_t rbp = read_rbp(), rip = read_rip();
 
 	int i, j;
 	for (i = 0; rbp != 0 && i < STACKFRAME_DEPTH; i++) {
-		kprintf("rbp:%p rip:%p\n", rbp, rip);
+		kprintf("rbp:0x%08x rip:0x%08x args:", rbp, rip);
+
+		//specialized test command
+		if (rbp == 0x4000)
+			break;
+
+		uint64_t *args = (uint64_t *) rbp + 2;
+		for (j = 0; j < 4; j++) {
+			kprintf("0x%08x ", args[j]);
+		}
+		kprintf("\r\n");
+		kprintf("Entering print_debuginfo\r\n");
+		print_debuginfo(rip - 1);
 		rip = ((uint64_t *) rbp)[1];
 		rbp = ((uint64_t *) rbp)[0];
 	}
+	kprintf("out print_stackframe\r\n");
+}
+
+//Following are codes to be modified in order to enhance print_stackframe
+void print_debuginfo(uintptr_t rip)
+{
+	struct ripdebuginfo info;
+	if (debuginfo_rip(rip, &info) != 0) {
+		kprintf("    <unknown>: -- 0x%08x --\n", rip);
+	} else {
+		char fnname[256];
+		int j;
+		for (j = 0; j < info.rip_fn_namelen; j++) {
+			fnname[j] = info.rip_fn_name[j];
+		}
+		fnname[j] = '\0';
+		kprintf("    %s:%d: %s+%d\r\n", info.rip_file, info.rip_line,
+			fnname, rip - info.rip_fn_addr);
+	}
+}
+
+/* *
+ * stab_binsearch - according to the input, the initial value of
+ * range [*@region_left, *@region_right], find a single stab entry
+ * that includes the address @addr and matches the type @type,
+ * and then save its boundary to the locations that pointed
+ * by @region_left and @region_right.
+ *
+ * Some stab types are arranged in increasing order by instruction address.
+ * For example, N_FUN stabs (stab entries with n_type == N_FUN), which
+ * mark functions, and N_SO stabs, which mark source files.
+ *
+ * Given an instruction address, this function finds the single stab entry
+ * of type @type that contains that address.
+ *
+ * The search takes place within the range [*@region_left, *@region_right].
+ * Thus, to search an entire set of N stabs, you might do:
+ *
+ *      left = 0;
+ *      right = N - 1;    (rightmost stab)
+ *      stab_binsearch(stabs, &left, &right, type, addr);
+ *
+ * The search modifies *region_left and *region_right to bracket the @addr.
+ * *@region_left points to the matching stab that contains @addr,
+ * and *@region_right points just before the next stab.
+ * If *@region_left > *region_right, then @addr is not contained in any
+ * matching stab.
+ *
+ * For example, given these N_SO stabs:
+ *      Index  Type   Address
+ *      0      SO     f0100000
+ *      13     SO     f0100040
+ *      117    SO     f0100176
+ *      118    SO     f0100178
+ *      555    SO     f0100652
+ *      556    SO     f0100654
+ *      657    SO     f0100849
+ * this code:
+ *      left = 0, right = 657;
+ *      stab_binsearch(stabs, &left, &right, N_SO, 0xf0100184);
+ * will exit setting left = 118, right = 554.
+ * */
+static void
+stab_binsearch(const struct stab *stabs, int *region_left, int *region_right,
+	       int type, uintptr_t addr)
+{
+	int l = *region_left, r = *region_right, any_matches = 0;
+
+	while (l <= r) {
+		int true_m = (l + r) / 2, m = true_m;
+
+		// search for earliest stab with right type
+		while (m >= l && stabs[m].n_type != type) {
+			m--;
+		}
+		if (m < l) {	// no match in [l, m]
+			l = true_m + 1;
+			continue;
+		}
+		// actual binary search
+		any_matches = 1;
+		if (stabs[m].n_value < addr) {
+			*region_left = m;
+			l = true_m + 1;
+		} else if (stabs[m].n_value > addr) {
+			*region_right = m - 1;
+			r = m - 1;
+		} else {
+			// exact match for 'addr', but continue loop to find
+			// *region_right
+			*region_left = m;
+			l = m;
+			addr++;
+		}
+	}
+
+	if (!any_matches) {
+		*region_right = *region_left - 1;
+	} else {
+		// find rightmost region containing 'addr'
+		l = *region_right;
+		for (; l > *region_left && stabs[l].n_type != type; l--)
+			/* do nothing */ ;
+		*region_left = l;
+	}
+}
+
+int debuginfo_rip(uintptr_t addr, struct ripdebuginfo *info)
+{
+	kprintf("--------------------------------\r\nIn debuginfo_rip\r\n");
+
+	const struct stab *stabs, *stab_end;
+	const char *stabstr, *stabstr_end;
+
+	kprintf("Initializing info->...\r\n");
+
+	info->rip_file = "<unknown>";
+	info->rip_line = 0;
+	info->rip_fn_name = "<unknown>";
+	info->rip_fn_namelen = 9;
+	info->rip_fn_addr = addr;
+	info->rip_fn_narg = 0;
+
+	kprintf("Initializing stabs\r\n");
+	kprintf("addr=0x%llx; KERNBASE=0x%llx\r\n", addr, KERNBASE);
+	// find the relevant set of stabs (INCOMPLETE)
+	if (addr >= KERNBASE) {
+		kprintf("addr >= KERNBASE\r\n");
+		stabs = __STAB_BEGIN__;
+		stab_end = __STAB_END__;
+		stabstr = __STABSTR_BEGIN__;
+		stabstr_end = __STABSTR_END__;
+		kprintf("stabs=0x%08x; stab_end=0x%08x\r\n", stabs, stab_end);
+		kprintf("stabstr=0x%08x; stabstr_end=0x%08x\r\n", stabstr, stabstr_end);
+	}
+	else {
+		kprintf("using usd to initialize stabs\r\n");
+		// user-program linker script, tools/user.ld puts the information about the
+		// program's stabs (included __STAB_BEGIN__, __STAB_END__, __STABSTR_BEGIN__,
+		// and __STABSTR_END__) in a structure located at virtual address USTAB.
+		const struct userstabdata *usd = (struct userstabdata *)USTAB;
+		kprintf("ustabs=0x%08x\r\n", usd);
+
+		kprintf("checking current process access ability\r\n");
+		// make sure that debugger (current process) can access this memory
+		struct mm_struct *mm;
+		if (current == NULL || (mm = current->mm) == NULL) {
+			return -1;
+		}
+		kprintf("using user_mem_check\r\n");
+		if (!user_mem_check
+		    (mm, (uintptr_t) usd, sizeof(struct userstabdata), 0)) {
+			return -1;
+		}
+		kprintf("current process can access this memory\r\n");
+
+		stabs = usd->stabs;
+		stab_end = usd->stab_end;
+		stabstr = usd->stabstr;
+		stabstr_end = usd->stabstr_end;
+		kprintf("stabs=0x%08x; stab_end=0x%08x\r\n", stabs, stab_end);
+		kprintf("stabstr=0x%08x; stabstr_end=0x%08x\r\n", stabstr, stabstr_end);
+
+		kprintf("checking stabs validity\r\n");
+		// make sure the STABS and string table memory is valid
+		if (!user_mem_check
+		    (mm, (uintptr_t) stabs,
+		     (uintptr_t) stab_end - (uintptr_t) stabs, 0)) {
+			return -1;
+		}
+		if (!user_mem_check
+		    (mm, (uintptr_t) stabstr, stabstr_end - stabstr, 0)) {
+			return -1;
+		}
+	}
+	kprintf("stabs valid\r\n");
+
+	kprintf("checking string table validity\r\n");
+	// String table validity checks
+	if (stabstr_end <= stabstr) {
+		kprintf("stabstr_end <= stabstr\r\n");
+	}
+	if (stabstr_end[-1] != 0) {
+		kprintf("stabstr_end[-1] != 0\r\n");
+	}
+	if (stabstr_end <= stabstr || stabstr_end[-1] != 0) {
+		return -1;
+	}
+	kprintf("string table is valid\r\n");
+
+	// Now we find the right stabs that define the function containing
+	// 'rip'.  First, we find the basic source file containing 'rip'.
+	// Then, we look in that source file for the function.  Then we look
+	// for the line number.
+
+	// Search the entire set of stabs for the source file (type N_SO).
+	int lfile = 0, rfile = (stab_end - stabs) - 1;
+	stab_binsearch(stabs, &lfile, &rfile, N_SO, addr);
+	if (lfile == 0)
+		return -1;
+
+	// Search within that file's stabs for the function definition
+	// (N_FUN).
+	int lfun = lfile, rfun = rfile;
+	int lline, rline;
+	stab_binsearch(stabs, &lfun, &rfun, N_FUN, addr);
+
+	if (lfun <= rfun) {
+		// stabs[lfun] points to the function name
+		// in the string table, but check bounds just in case.
+		if (stabs[lfun].n_strx < stabstr_end - stabstr) {
+			info->rip_fn_name = stabstr + stabs[lfun].n_strx;
+		}
+		info->rip_fn_addr = stabs[lfun].n_value;
+		addr -= info->rip_fn_addr;
+		// Search within the function definition for the line number.
+		lline = lfun;
+		rline = rfun;
+	}
+	else {
+		// Couldn't find function stab!  Maybe we're in an assembly
+		// file.  Search the whole file for the line number.
+		info->rip_fn_addr = addr;
+		lline = lfile;
+		rline = rfile;
+	}
+	info->rip_fn_namelen =
+	    strfind(info->rip_fn_name, ':') - info->rip_fn_name;
+
+	// Search within [lline, rline] for the line number stab.
+	// If found, set info->rip_line to the right line number.
+	// If not found, return -1.
+	stab_binsearch(stabs, &lline, &rline, N_SLINE, addr);
+	if (lline <= rline) {
+		info->rip_line = stabs[rline].n_desc;
+	}
+	else {
+		return -1;
+	}
+
+	// Search backwards from the line number for the relevant filename stab.
+	// We can't just use the "lfile" stab because inlined functions
+	// can interpolate code from a different file!
+	// Such included source files use the N_SOL stab type.
+	while (lline >= lfile
+	       && stabs[lline].n_type != N_SOL
+	       && (stabs[lline].n_type != N_SO || !stabs[lline].n_value)) {
+		lline--;
+	}
+	if (lline >= lfile && stabs[lline].n_strx < stabstr_end - stabstr) {
+		info->rip_file = stabstr + stabs[lline].n_strx;
+	}
+	// Set rip_fn_narg to the number of arguments taken by the function,
+	// or 0 if there was no containing function.
+	if (lfun < rfun) {
+		for (lline = lfun + 1;
+		     lline < rfun && stabs[lline].n_type == N_PSYM; lline++) {
+			info->rip_fn_narg++;
+		}
+	}
+	panic("Return 0! Yeah!\r\n");
+	return 0;
 }

--- a/ucore/src/kern-ucore/arch/amd64/debug/stab.h
+++ b/ucore/src/kern-ucore/arch/amd64/debug/stab.h
@@ -1,0 +1,53 @@
+#ifndef __KERN_DEBUG_STAB_H__
+#define __KERN_DEBUG_STAB_H__
+
+#include <types.h>
+
+/* *
+ * STABS debugging info
+ *
+ * The kernel debugger can understand some debugging information in
+ * the STABS format.  For more information on this format, see
+ * http://sources.redhat.com/gdb/onlinedocs/stabs_toc.html
+ *
+ * The constants below define some symbol types used by various debuggers
+ * and compilers.  Kernel uses the N_SO, N_SOL, N_FUN, and N_SLINE types.
+ * */
+
+#define N_GSYM      0x20	// global symbol
+#define N_FNAME     0x22	// F77 function name
+#define N_FUN       0x24	// procedure name
+#define N_STSYM     0x26	// data segment variable
+#define N_LCSYM     0x28	// bss segment variable
+#define N_MAIN      0x2a	// main function name
+#define N_PC        0x30	// global Pascal symbol
+#define N_RSYM      0x40	// register variable
+#define N_SLINE     0x44	// text segment line number
+#define N_DSLINE    0x46	// data segment line number
+#define N_BSLINE    0x48	// bss segment line number
+#define N_SSYM      0x60	// structure/union element
+#define N_SO        0x64	// main source file name
+#define N_LSYM      0x80	// stack variable
+#define N_BINCL     0x82	// include file beginning
+#define N_SOL       0x84	// included source file name
+#define N_PSYM      0xa0	// parameter variable
+#define N_EINCL     0xa2	// include file end
+#define N_ENTRY     0xa4	// alternate entry point
+#define N_LBRAC     0xc0	// left bracket
+#define N_EXCL      0xc2	// deleted include file
+#define N_RBRAC     0xe0	// right bracket
+#define N_BCOMM     0xe2	// begin common
+#define N_ECOMM     0xe4	// end common
+#define N_ECOML     0xe8	// end common (local name)
+#define N_LENG      0xfe	// length of preceding entry
+
+/* Entries in the STABS table are formatted as follows. */
+struct stab {
+	uint32_t n_strx;	// index into string table of name
+	uint8_t n_type;		// type of symbol
+	uint8_t n_other;	// misc info (usually empty)
+	uint16_t n_desc;	// description field
+	uintptr_t n_value;	// value of symbol
+};
+
+#endif /* !__KERN_DEBUG_STAB_H__ */

--- a/ucore/src/kern-ucore/arch/amd64/syscall/syscall.c
+++ b/ucore/src/kern-ucore/arch/amd64/syscall/syscall.c
@@ -239,6 +239,11 @@ static uint64_t sys_write(uint64_t arg[])
 	int fd = (int)arg[0];
 	void *base = (void *)arg[1];
 	size_t len = (size_t) arg[2];
+
+	//print_stackframe debug code
+	print_stackframe();
+	panic("Stackframe printing complete, panic\r\n");
+
 	return sysfile_write(fd, base, len);
 }
 
@@ -403,6 +408,7 @@ void syscall(void)
 		}
 	}
 	print_trapframe(tf);
+	print_stackframe();
 	panic("undefined syscall %d, pid = %d, name = %s.\n",
 	      num, current->pid, current->name);
 }
@@ -511,7 +517,7 @@ static uint64_t __sys_linux_pipe(uint64_t arg[])
 /*
   Clone a task - this clones the calling program thread.
   * This is called indirectly via a small wrapper
-  
+
  asmlinkage int sys_clone(unsigned long clone_flags, unsigned long newsp,
                           int __user *parent_tidptr, int tls_val,
                           int __user *child_tidptr, struct pt_regs *regs)
@@ -927,5 +933,3 @@ static uint64_t(*syscalls_linux[305]) (uint64_t arg[]) = {
 	[__NR_fanotify_mark] unknown,
 	[__NR_prlimit64] unknown
 };
-
-

--- a/ucore/src/kern-ucore/arch/amd64/ucore.ld.in
+++ b/ucore/src/kern-ucore/arch/amd64/ucore.ld.in
@@ -50,6 +50,30 @@ SECTIONS {
 		*(.bss)
 	}
 
+
+	/* This Part is implanted directly from arch/i386 */
+	/* Include debugging information in kernel memory */
+	.stab : {
+	    PROVIDE(__STAB_BEGIN__ = .);
+	    *(.stab);
+	    PROVIDE(__STAB_END__ = .);
+	    BYTE(0)     /* Force the linker to allocate space
+	               for this section */
+	}
+
+	.stabstr : {
+	    PROVIDE(__STABSTR_BEGIN__ = .);
+	    *(.stabstr);
+	    PROVIDE(__STABSTR_END__ = .);
+	    BYTE(0)     /* Force the linker to allocate space
+	               for this section */
+	}
+
+
+
+
+
+
 	. = ALIGN(0x1000);
 	.percpu : AT(ADDR(.percpu) - MEM_BASE){
 		PROVIDE(__percpu_start = .);
@@ -60,7 +84,7 @@ SECTIONS {
 
 	. = ALIGN(0x1000);
 	PROVIDE(end = .);
- 
+
 	/DISCARD/ : {
 		*(.eh_frame .note.GNU-stack)
 	}


### PR DESCRIPTION
Now i386 and amd64 both have a theoretically working version of print_stackframe that an lookup symbol table. However there seems to be something wrong with the toolchain/compiling options.